### PR TITLE
fix: accept numeric timestamps for date fields in schemas

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -21,8 +21,8 @@ export const TickTickTaskSchema = z.object({
   desc: z.string().optional(),
   timeZone: z.string().optional(),
   repeatFlag: z.string().optional(),
-  startDate: z.string().optional(),
-  dueDate: z.string().optional(),
+  startDate: z.union([z.string(), z.number()]).optional(),
+  dueDate: z.union([z.string(), z.number()]).optional(),
   reminders: z.array(z.string()).optional(),
   priority: z.number().optional(),
   status: z.number(),
@@ -35,7 +35,7 @@ export const TickTickTaskSchema = z.object({
         status: z.number(),
         title: z.string(),
         sortOrder: z.number().optional(),
-        startDate: z.string().optional(),
+        startDate: z.union([z.string(), z.number()]).optional(),
         isAllDay: z.boolean().optional(),
         timeZone: z.string().optional(),
         completedTime: z.union([z.string(), z.number()]).optional(),
@@ -47,9 +47,9 @@ export const TickTickTaskSchema = z.object({
 export const TickTickCheckListItemSchema = z.object({
   title: z.string().describe('Subtask item title'),
   startDate: z
-    .string()
+    .union([z.string(), z.number()])
     .optional()
-    .describe(`Subtask item start date in "yyyy-MM-dd'T'HH:mm:ssZ" format`),
+    .describe(`Subtask item start date in "yyyy-MM-dd'T'HH:mm:ssZ" format or Unix timestamp`),
   isAllDay: z.boolean().optional().describe('Is all day subtask item'),
   sortOrder: z.number().optional().describe('Subtask item sort order'),
   timeZone: z


### PR DESCRIPTION
## Summary

The TickTick API returns `startDate` and `dueDate` as Unix timestamps (numbers) in some cases, but the Zod schemas only accepted strings. This caused validation errors when reading tasks with subtasks that have dates set.

**Error example:**
```
MCP error -32603: Invalid input: [{"code":"invalid_type","expected":"string","received":"number","path":["items",0,"startDate"]}]
```

## Changes

- `TickTickTaskSchema.startDate`: string → string | number
- `TickTickTaskSchema.dueDate`: string → string | number
- `TickTickTaskSchema.items[].startDate`: string → string | number
- `TickTickCheckListItemSchema.startDate`: string → string | number

This follows the existing pattern already used for `completedTime` fields.

## Testing

Before fix: `get_project_with_data` and `get_task_by_ids` fail on tasks with subtasks that have dates
After fix: These operations complete successfully

Fixes #9